### PR TITLE
fixes UTC-turnover bug leading to missing data

### DIFF
--- a/main/tasks.py
+++ b/main/tasks.py
@@ -56,7 +56,7 @@ def identify_start_data_fetch(fitbit_data, data_key, month):
         elif month:
             return fitbit_data, month + '-01'
     return fitbit_data, fitbit_data['user']['memberSince']
-    #return fitbit_data, "2018-10-28" # THIS IS JUST FOR TESTING TO KEEP THE DATA MANAGEABLE!
+    #return fitbit_data, "2019-01-02" # THIS IS JUST FOR TESTING TO KEEP THE DATA MANAGEABLE!
 
 
 def get_single_endpoint(url, start_date, header):
@@ -80,7 +80,7 @@ def update_endpoints(oh_member, fitbit_data, header, old_file_id, month):
                             start_date,
                             '%Y-%m-%d').date()
             end_date = datetime.date.today()
-            while start_date <= end_date:
+            while start_date < end_date:
                 new_data = get_single_endpoint(url, start_date, header)
                 try:
                     new_data = new_data[endpoint]


### PR DESCRIPTION
Currently there's an issue that can lead to missing data after a given hour in the day (see image at the end). This is a result of the UTC turnover in which the `current day` in UTC is actually `tomorrow` in the Fitbit user's time zone. As a result the data import task rolls over to the new day despite there not being any data available. 

This empty entry leads to the actual `current day` never been touched again, thus missing out on the last few hours of data of the day. The simple fix: Don't try to import data from `today`, which is unproblematic as the data is automatically updated in infrequent intervals in any case and users can't trigger the update.

![image](https://user-images.githubusercontent.com/674899/52666216-8156e700-2ec2-11e9-9c25-fb10f41a8522.png)
